### PR TITLE
Create screenshot directory on demand if needed

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -168,8 +168,15 @@ open class Snapshot: NSObject {
             let screenshot = window.screenshot()
             guard let simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
             let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
+        
             do {
+                var isDirectory: ObjCBool = false
+                if !FileManager.default.fileExists(atPath: screenshotsDir.path, isDirectory: &isDirectory) || !isDirectory.boolValue {
+                    try FileManager.default.createDirectory(at: screenshotsDir, withIntermediateDirectories: true, attributes: nil)
+                }
+
                 try screenshot.pngRepresentation.write(to: path)
+                
             } catch let error {
                 print("Problem writing screenshot: \(name) to \(path)")
                 print(error)


### PR DESCRIPTION
When running snapshot tests locally, my screenshots folder didn't exist yet which let to the screenshots never being saved, these changes fixed that

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
